### PR TITLE
Added current() test to NodeModel

### DIFF
--- a/src/models/NodeModel.php
+++ b/src/models/NodeModel.php
@@ -147,4 +147,31 @@ class NodeModel extends Model
         }
         return false;
     }
+
+    public function current()
+    {
+        switch ($this->type) {
+            case 'url':
+                if (substr(Craft::$app->request->getPathInfo(), 0, strlen($this->url)) === $this->url) {
+                    return true;
+                }
+                if (substr("/". Craft::$app->request->getPathInfo(), 0, strlen($this->url)) === $this->url) {
+                    return true;
+                }
+
+                break;
+            default:
+                if ($this->url === Craft::$app->request->getAbsoluteUrl()) {
+                    return true;
+                }
+                
+                if(strpos(Craft::$app->request->getAbsoluteUrl(), '?')) {
+                    if(explode('?', Craft::$app->request->getAbsoluteUrl())[0] === $this->url) {
+                        return true;
+                    }
+                }
+                break;
+        }
+        return false;
+    }    
 }


### PR DESCRIPTION
Adds a function to NodeModel called `current()` which lets you to test whether a node URL matches the current page URL exactly.

This is different from the existing `active()` function which will return true if one of the nodes children is active.